### PR TITLE
[Indigo] [DatePicker] Finish building magic shortcut commands for DatePicker.

### DIFF
--- a/front-end/components/business-process/common/date-picker.js
+++ b/front-end/components/business-process/common/date-picker.js
@@ -108,9 +108,6 @@ export const BPDatePicker = ({label, onChange, baseDate, callBack}) => {
     }
 
     const input = inputValue;
-    // if (inputValue.includes('-') || inputValue.includes('+')) {
-
-    // }
     const inputValueArr = input.split(/[:\s]/i);
 
     const parsedValue = inputValueArr[0];
@@ -233,7 +230,6 @@ export const BPDatePicker = ({label, onChange, baseDate, callBack}) => {
                     openTo="day"
                     value={value}
                     onChange={(newValue) => {
-                      // console.log(newValue);
                       setValue(newValue);
                       callBack(newValue);
                     }}

--- a/front-end/components/business-process/common/date-picker.js
+++ b/front-end/components/business-process/common/date-picker.js
@@ -48,7 +48,7 @@ export const BPDatePicker = ({label, onChange, baseDate}) => {
 
   const onInputFinish = (text) => {
     try {
-      const parsedDate = parseDate(text, baseDate);
+      const parsedDate = parseDate(text, baseDate || new Date());
       setValue(parsedDate);
     } catch (e) {
       console.error(e.toString());

--- a/front-end/components/business-process/common/date-picker.js
+++ b/front-end/components/business-process/common/date-picker.js
@@ -3,6 +3,7 @@ import {BPDimens, BPStandards} from '../../../utils/business-process/standards';
 
 import BPTextInput from './text-input';
 
+import TextField from '@mui/material/TextField';
 import AdapterDateFns from '@mui/lab/AdapterDateFns';
 import LocalizationProvider from '@mui/lab/LocalizationProvider';
 import StaticDateTimePicker from '@mui/lab/StaticDateTimePicker';
@@ -10,7 +11,7 @@ import {ClickAwayListener, Popper} from '@mui/material';
 
 import {dateOptions} from '../../../utils/business-process/date-options';
 
-export const BPDatePicker = ({label, onChange}) => {
+export const BPDatePicker = ({label, onChange, baseDate, callBack}) => {
   // Date picker value.
   const [value, setValue] = useState(null);
 
@@ -27,9 +28,118 @@ export const BPDatePicker = ({label, onChange}) => {
     setIsOpen(false);
   };
 
+  const addAction = (base, amount, flag) => {
+    switch (flag) {
+      case 'h':
+        const newhour = parseInt(base.getHours()) + parseInt(amount);
+        base.setHours(newhour);
+        break;
+      case 'd':
+        const newdate = parseInt(base.getDate()) + parseInt(amount);
+        base.setDate(newdate);
+        break;
+      case 'm':
+        const newmin = parseInt(base.getMinutes()) + parseInt(amount);
+        base.setMinutes(newmin);
+        break;
+      case 'mo':
+        const newmonth = parseInt(base.getMonth()) + parseInt(amount);
+        base.setMonth(newmonth);
+        break;
+      case 'y':
+        const newyear = parseInt(base.getFullYear()) + parseInt(amount);
+        base.setFullYear(newyear);
+        break;
+    }
+  };
+  const minusAction = (base, amount, flag) => {
+    switch (flag) {
+      case 'h':
+        const newhour = parseInt(base.getHours()) - parseInt(amount);
+        base.setHours(newhour);
+        break;
+      case 'd':
+        const newdate = parseInt(base.getDate()) - parseInt(amount);
+        base.setDate(newdate);
+        break;
+      case 'm':
+        const newmin = parseInt(base.getMinutes()) - parseInt(amount);
+        base.setMinutes(newmin);
+        break;
+      case 'mo':
+        const newmonth = parseInt(base.getMonth()) - parseInt(amount);
+        base.setMonth(newmonth);
+        break;
+      case 'y':
+        const newyear = parseInt(base.getFullYear()) - parseInt(amount);
+        base.setFullYear(newyear);
+        break;
+    }
+  };
+
   // Process the input value into datepicker value.
   useEffect(() => {
-    // TODO
+    const changeFlag = false;
+    console.log(baseDate);
+    const updatedDate = new Date(baseDate);
+
+    // console.log(baseDate);
+    if (inputValue.includes('-') || inputValue.includes('+')) {
+      if (inputValue.length >= 4) {
+        const reviseList = inputValue.split(' ');
+        reviseList.forEach((action) => {
+          // console.log(updatedDate);
+          const amount = action.charAt(1);
+          const flag = action.substring(2);
+          if (action.charAt(0) == '+') {
+            addAction(updatedDate, amount, flag);
+            changeFlag = true;
+          } else {
+            minusAction(updatedDate, amount, flag);
+            changeFlag = true;
+          }
+        });
+      }
+    }
+    // console.log(updatedDate);
+    if (changeFlag) {
+      setValue(updatedDate);
+      return;
+    }
+
+    const input = inputValue;
+    // if (inputValue.includes('-') || inputValue.includes('+')) {
+
+    // }
+    const inputValueArr = input.split(/[:\s]/i);
+
+    const parsedValue = inputValueArr[0];
+    const hour = '00';
+    const minutes = '00';
+
+    if (inputValueArr.length > 1) {
+      hour = inputValueArr[1].replace(/\D/g, '');
+      parsedValue += ' ' + hour;
+    }
+    if (inputValueArr.length > 2) {
+      minutes = inputValueArr[2].replace(/\D/g, '');
+      if (/^\d+$/.test(minutes)) {
+        parsedValue += ':' + minutes;
+      }
+    }
+    if (input.toLowerCase().includes('am')) {
+      if (! /^\d+$/.test(minutes)) {
+        parsedValue += ':' + '00';
+      }
+      parsedValue += ' AM';
+    } else if (input.toLowerCase().includes('pm')) {
+      if (! /^\d+$/.test(minutes)) {
+        parsedValue += ':' + '00';
+      }
+      parsedValue += ' PM';
+    }
+
+    setValue(parsedValue);
   }, [inputValue]);
 
   // Process the datepicker value into input value.
@@ -123,12 +233,14 @@ export const BPDatePicker = ({label, onChange}) => {
                     openTo="day"
                     value={value}
                     onChange={(newValue) => {
+                      // console.log(newValue);
                       setValue(newValue);
+                      callBack(newValue);
                     }}
                     onAccept={() => {
                       handlePopoverClose();
                     }}
-                    renderInput={(params) => <></>}
+                    renderInput={(params) => <TextField {...params}/>}
                   />
                 </LocalizationProvider>
               </div>

--- a/front-end/components/business-process/common/date-picker.js
+++ b/front-end/components/business-process/common/date-picker.js
@@ -3,8 +3,6 @@ import {BPDimens, BPStandards} from '../../../utils/business-process/standards';
 
 import BPTextInput from './text-input';
 
-import InfoIcon from '@mui/icons-material/Info';
-import Tooltip from '@mui/material/Tooltip';
 import TextField from '@mui/material/TextField';
 import AdapterDateFns from '@mui/lab/AdapterDateFns';
 import LocalizationProvider from '@mui/lab/LocalizationProvider';
@@ -12,6 +10,7 @@ import StaticDateTimePicker from '@mui/lab/StaticDateTimePicker';
 import {ClickAwayListener, Popper} from '@mui/material';
 
 import {dateOptions} from '../../../utils/business-process/date-options';
+import {DatePickerHelper} from "./support/date-picker-helper";
 
 export const BPDatePicker = ({label, onChange, baseDate, callBack}) => {
   // Date picker value.
@@ -148,12 +147,6 @@ export const BPDatePicker = ({label, onChange, baseDate, callBack}) => {
     }
   }, [value]);
 
-  const IconWithTooltip = () => (
-    <Tooltip title='Input could revise the base date. Date modifier h (hour), m (minute), d (day), mo (month), y (year). It includes three parts: modifier prefix (- or +), the modifying amount (a number), and the modifying unit (the shortcut for time units). e.g. +1d represents plus one day' arrow>
-      <InfoIcon fontSize="small"/>
-    </Tooltip>
-  );
-
   return (
     <div
       style={{
@@ -176,13 +169,19 @@ export const BPDatePicker = ({label, onChange, baseDate, callBack}) => {
             style={{
               width: '100%',
             }}
-            label={
-              <div>
+            label={(
+              <div
+                style={{
+                  display: 'flex',
+                  flexDirection: 'row',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                }}
+              >
                 {label}
-                <IconWithTooltip />
+                <DatePickerHelper/>
               </div>
-
-            }
+            )}
             boxRef={(ref) => {
               boxRef.current = ref;
             }}

--- a/front-end/components/business-process/common/date-picker.js
+++ b/front-end/components/business-process/common/date-picker.js
@@ -3,6 +3,8 @@ import {BPDimens, BPStandards} from '../../../utils/business-process/standards';
 
 import BPTextInput from './text-input';
 
+import InfoIcon from '@mui/icons-material/Info';
+import Tooltip from '@mui/material/Tooltip';
 import TextField from '@mui/material/TextField';
 import AdapterDateFns from '@mui/lab/AdapterDateFns';
 import LocalizationProvider from '@mui/lab/LocalizationProvider';
@@ -146,6 +148,12 @@ export const BPDatePicker = ({label, onChange, baseDate, callBack}) => {
     }
   }, [value]);
 
+  const IconWithTooltip = () => (
+    <Tooltip title='Input could revise the base date. Date modifier h (hour), m (minute), d (day), mo (month), y (year). It includes three parts: modifier prefix (- or +), the modifying amount (a number), and the modifying unit (the shortcut for time units). e.g. +1d represents plus one day' arrow>
+      <InfoIcon fontSize="small"/>
+    </Tooltip>
+  );
+
   return (
     <div
       style={{
@@ -168,7 +176,13 @@ export const BPDatePicker = ({label, onChange, baseDate, callBack}) => {
             style={{
               width: '100%',
             }}
-            label={label}
+            label={
+              <div>
+                {label}
+                <IconWithTooltip />
+              </div>
+
+            }
             boxRef={(ref) => {
               boxRef.current = ref;
             }}
@@ -185,6 +199,7 @@ export const BPDatePicker = ({label, onChange, baseDate, callBack}) => {
             }}
             onClick={() => setIsOpen(true)}
           />
+
           <Popper
             id={isOpen ? 'bp-date-picker' : undefined}
             open={isOpen}

--- a/front-end/components/business-process/common/date-picker.js
+++ b/front-end/components/business-process/common/date-picker.js
@@ -11,6 +11,7 @@ import {ClickAwayListener, Popper} from '@mui/material';
 
 import {dateOptions} from '../../../utils/business-process/date-options';
 import {DatePickerHelper} from './support/date-picker-helper';
+import {parseDate} from "./support/date-picker-processor";
 
 export const BPDatePicker = ({label, onChange, baseDate}) => {
   // Date picker value.
@@ -29,114 +30,9 @@ export const BPDatePicker = ({label, onChange, baseDate}) => {
     setIsOpen(false);
   };
 
-  const addAction = (base, amount, flag) => {
-    switch (flag) {
-      case 'h':
-        const newhour = parseInt(base.getHours()) + parseInt(amount);
-        base.setHours(newhour);
-        break;
-      case 'd':
-        const newdate = parseInt(base.getDate()) + parseInt(amount);
-        base.setDate(newdate);
-        break;
-      case 'm':
-        const newmin = parseInt(base.getMinutes()) + parseInt(amount);
-        base.setMinutes(newmin);
-        break;
-      case 'mo':
-        const newmonth = parseInt(base.getMonth()) + parseInt(amount);
-        base.setMonth(newmonth);
-        break;
-      case 'y':
-        const newyear = parseInt(base.getFullYear()) + parseInt(amount);
-        base.setFullYear(newyear);
-        break;
-    }
-  };
-  const minusAction = (base, amount, flag) => {
-    switch (flag) {
-      case 'h':
-        const newhour = parseInt(base.getHours()) - parseInt(amount);
-        base.setHours(newhour);
-        break;
-      case 'd':
-        const newdate = parseInt(base.getDate()) - parseInt(amount);
-        base.setDate(newdate);
-        break;
-      case 'm':
-        const newmin = parseInt(base.getMinutes()) - parseInt(amount);
-        base.setMinutes(newmin);
-        break;
-      case 'mo':
-        const newmonth = parseInt(base.getMonth()) - parseInt(amount);
-        base.setMonth(newmonth);
-        break;
-      case 'y':
-        const newyear = parseInt(base.getFullYear()) - parseInt(amount);
-        base.setFullYear(newyear);
-        break;
-    }
-  };
-
   // Process the input value into datepicker value.
   useEffect(() => {
-    let changeFlag = false;
-    const updatedDate = new Date(baseDate);
-
-    // console.log(baseDate);
-    if (inputValue.includes('-') || inputValue.includes('+')) {
-      if (inputValue.includes(' ')) {
-        inputValue.replace(' ', ', ');
-        const reviseList = inputValue.split(' ');
-        reviseList.forEach((action) => {
-          const amount = action.replace(/\D/g, '');
-          const flag = action.replace(/\W/g, '').replace(/\d/g, '');
-          if (action.charAt(0) === '+') {
-            addAction(updatedDate, amount, flag);
-            changeFlag = true;
-          } else {
-            minusAction(updatedDate, amount, flag);
-            changeFlag = true;
-          }
-        });
-      }
-    }
-    // console.log(updatedDate);
-    if (changeFlag) {
-      setValue(updatedDate);
-      return;
-    }
-
-    const input = inputValue;
-    const inputValueArr = input.split(/[:\s]/i);
-
-    let parsedValue = inputValueArr[0];
-    let hour = '00';
-    let minutes = '00';
-
-    if (inputValueArr.length > 1) {
-      hour = inputValueArr[1].replace(/\D/g, '');
-      parsedValue += ' ' + hour;
-    }
-    if (inputValueArr.length > 2) {
-      minutes = inputValueArr[2].replace(/\D/g, '');
-      if (/^\d+$/.test(minutes)) {
-        parsedValue += ':' + minutes;
-      }
-    }
-    if (input.toLowerCase().includes('am')) {
-      if (! /^\d+$/.test(minutes)) {
-        parsedValue += ':' + '00';
-      }
-      parsedValue += ' AM';
-    } else if (input.toLowerCase().includes('pm')) {
-      if (! /^\d+$/.test(minutes)) {
-        parsedValue += ':' + '00';
-      }
-      parsedValue += ' PM';
-    }
-
-    setValue(parsedValue);
+    // setValue(parseDate(inputValue, baseDate));
   }, [inputValue]);
 
   // Process the datepicker value into input value.
@@ -149,6 +45,16 @@ export const BPDatePicker = ({label, onChange, baseDate}) => {
       }
     }
   }, [value]);
+
+  const onInputFinish = (text) => {
+    try {
+      const parsedDate = parseDate(text, baseDate);
+      setValue(parsedDate);
+    } catch (e) {
+      console.error(e.toString());
+      // TODO: Set error state to the input field.
+    }
+  };
 
   return (
     <div
@@ -193,8 +99,9 @@ export const BPDatePicker = ({label, onChange, baseDate}) => {
             onTextChange={(newValue) => {
               setInputValue(newValue);
             }}
-            onEnterPress={() => {
+            onEnterPress={(e) => {
               handlePopoverClose();
+              onInputFinish(e.target.value);
             }}
             onEscPress={() => {
               handlePopoverClose();

--- a/front-end/components/business-process/common/date-picker.js
+++ b/front-end/components/business-process/common/date-picker.js
@@ -10,9 +10,9 @@ import StaticDateTimePicker from '@mui/lab/StaticDateTimePicker';
 import {ClickAwayListener, Popper} from '@mui/material';
 
 import {dateOptions} from '../../../utils/business-process/date-options';
-import {DatePickerHelper} from "./support/date-picker-helper";
+import {DatePickerHelper} from './support/date-picker-helper';
 
-export const BPDatePicker = ({label, onChange, baseDate, callBack}) => {
+export const BPDatePicker = ({label, onChange, baseDate}) => {
   // Date picker value.
   const [value, setValue] = useState(null);
 
@@ -80,7 +80,7 @@ export const BPDatePicker = ({label, onChange, baseDate, callBack}) => {
 
   // Process the input value into datepicker value.
   useEffect(() => {
-    const changeFlag = false;
+    let changeFlag = false;
     const updatedDate = new Date(baseDate);
 
     // console.log(baseDate);
@@ -91,7 +91,7 @@ export const BPDatePicker = ({label, onChange, baseDate, callBack}) => {
         reviseList.forEach((action) => {
           const amount = action.replace(/\D/g, '');
           const flag = action.replace(/\W/g, '').replace(/\d/g, '');
-          if (action.charAt(0) == '+') {
+          if (action.charAt(0) === '+') {
             addAction(updatedDate, amount, flag);
             changeFlag = true;
           } else {
@@ -110,9 +110,9 @@ export const BPDatePicker = ({label, onChange, baseDate, callBack}) => {
     const input = inputValue;
     const inputValueArr = input.split(/[:\s]/i);
 
-    const parsedValue = inputValueArr[0];
-    const hour = '00';
-    const minutes = '00';
+    let parsedValue = inputValueArr[0];
+    let hour = '00';
+    let minutes = '00';
 
     if (inputValueArr.length > 1) {
       hour = inputValueArr[1].replace(/\D/g, '');
@@ -144,6 +144,9 @@ export const BPDatePicker = ({label, onChange, baseDate, callBack}) => {
     // TODO
     if (value) {
       setInputValue(value.toLocaleString('en-US', dateOptions));
+      if (onChange) {
+        onChange(value);
+      }
     }
   }, [value]);
 
@@ -244,7 +247,6 @@ export const BPDatePicker = ({label, onChange, baseDate, callBack}) => {
                     value={value}
                     onChange={(newValue) => {
                       setValue(newValue);
-                      callBack(newValue);
                     }}
                     onAccept={() => {
                       handlePopoverClose();

--- a/front-end/components/business-process/common/date-picker.js
+++ b/front-end/components/business-process/common/date-picker.js
@@ -80,17 +80,16 @@ export const BPDatePicker = ({label, onChange, baseDate, callBack}) => {
   // Process the input value into datepicker value.
   useEffect(() => {
     const changeFlag = false;
-    console.log(baseDate);
     const updatedDate = new Date(baseDate);
 
     // console.log(baseDate);
     if (inputValue.includes('-') || inputValue.includes('+')) {
-      if (inputValue.length >= 4) {
+      if (inputValue.includes(' ')) {
+        inputValue.replace(' ', ', ');
         const reviseList = inputValue.split(' ');
         reviseList.forEach((action) => {
-          // console.log(updatedDate);
-          const amount = action.charAt(1);
-          const flag = action.substring(2);
+          const amount = action.replace(/\D/g, '');
+          const flag = action.replace(/\W/g, '').replace(/\d/g, '');
           if (action.charAt(0) == '+') {
             addAction(updatedDate, amount, flag);
             changeFlag = true;

--- a/front-end/components/business-process/common/support/date-picker-helper.js
+++ b/front-end/components/business-process/common/support/date-picker-helper.js
@@ -1,8 +1,20 @@
 import React, {useEffect, useState} from 'react';
-import {IconBolt, IconHelp, IconWand, IconX} from '@tabler/icons';
+import {IconBolt, IconHelp, IconRotateClockwise2, IconWand, IconX} from '@tabler/icons';
 import {Modal} from '@mui/material';
 import styled from 'styled-components';
 import {BPColors, BPDimens, BPStandards} from '../../../../utils/business-process/standards';
+
+const HelperModalOpenButton = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 0 4px;
+  cursor: pointer;
+  
+  &:hover {
+    color: ${BPColors.gray[900]};
+  }
+`;
 
 // The styled div for the helper modal root.
 const HelperModalDiv = styled.div`
@@ -36,7 +48,7 @@ const HelperModalDiv = styled.div`
     justify-content: center;
     column-gap: 4px;
     padding: 10px 11px 10px 14px;
-    margin: 0 10px;
+    margin: 0 13px;
     border-radius: ${BPDimens.smallRadius}px;
     font-size: 16px;
     font-weight: 500;
@@ -106,12 +118,13 @@ const HelperModalContentContainer = ({title, icon, color = BPColors.brand, child
           display: 'flex',
           alignItems: 'center',
           justifyContent: 'center',
-          marginLeft: 50,
+          marginLeft: 45,
+          marginRight: 5,
           borderRadius: BPDimens.smallRadius,
-          backgroundColor: color + '0f', // Fade out the color for background.
+          backgroundColor: color + '16', // Fade out the color for background.
         }}
       >
-        <TitleIconComponent width={26} height={26} strokeWidth={1.9} color={color}/>
+        <TitleIconComponent width={28} height={28} strokeWidth={1.9} color={color}/>
       </div>
       <div
         className='helper-modal-content-children'
@@ -125,7 +138,8 @@ const HelperModalContentContainer = ({title, icon, color = BPColors.brand, child
       >
         <h1
           style={{
-            height: 42,
+            height: 50,
+            paddingBottom: 8,
             fontSize: 42,
             fontWeight: '500',
             lineHeight: 1.0,
@@ -157,15 +171,7 @@ export const DatePickerHelper = ({onOpen, onClose}) => {
 
   return (
     <>
-      <div
-        style={{
-          flex: 1,
-          display: 'flex',
-          justifyContent: 'center',
-          alignItems: 'center',
-          padding: '0 4px',
-          cursor: 'pointer',
-        }}
+      <HelperModalOpenButton
         onClick={() => setIsModalOpen(true)}
       >
         <IconHelp
@@ -173,7 +179,7 @@ export const DatePickerHelper = ({onOpen, onClose}) => {
           height={16}
           strokeWidth={2.2}
         />
-      </div>
+      </HelperModalOpenButton>
       <Modal
         open={isModalOpen}
         onClose={() => setIsModalOpen(false)}
@@ -239,13 +245,21 @@ export const DatePickerHelper = ({onOpen, onClose}) => {
                 One modifier is assembled by three parts: <b>Prefix</b>, <b>Amount</b> and <b>Unit</b>. Here are some examples: <code>+1d</code> (add a day), <code>-10h</code> (subtract 10 hours).
               </p>
               <p>
-                A prefix could be <code>+</code> or <code>-</code> to indicate the direction of the adjustment. If you want to pick a date (or time) that is in the past (need to subtract some times), you can use the prefix <code>-</code>. And if you want to pick a date (or time) that is in the future (need to add some times), you can use the prefix <code>+</code>.
+                A <b>prefix</b> could be <code>+</code> or <code>-</code> to indicate the direction of the adjustment. If you want to pick a date (or time) that is in the past (need to subtract some times), you can use the prefix <code>-</code>. And if you want to pick a date (or time) that is in the future (need to add some times), you can use the prefix <code>+</code>.
               </p>
               <p>
-                To be continued...
+                The <b>amount</b> is an integer (no decimals allowed) that indicates how many units you want to adjust. For example, <code>+1d</code> means add one day, <code>-10h</code> means subtract 10 hours. And it could also be like <code>-90m</code> to subtract 90 minutes because the amount is not necessary to be less than 60 minutes or 24 hours.
               </p>
             </HelperModalContentContainer>
-            <HelperModalContentContainer title={'Supercharge Input'} icon={IconBolt} color={'#1d4ed8'}>
+            <HelperModalContentContainer title={'Quick Interval'} icon={IconRotateClockwise2} color={'#059669'}>
+              <p>
+                This is the most convenient way to &quot;paste&quot; a date and time.
+              </p>
+              <p>
+                To be continued.
+              </p>
+            </HelperModalContentContainer>
+            <HelperModalContentContainer title={'Input Supercharge'} icon={IconBolt} color={'#1d4ed8'}>
               <p>
                 This is the most convenient way to &quot;paste&quot; a date and time.
               </p>

--- a/front-end/components/business-process/common/support/date-picker-helper.js
+++ b/front-end/components/business-process/common/support/date-picker-helper.js
@@ -159,7 +159,12 @@ const HelperModalContentContainer = ({title, icon, color = BPColors.brand, child
 };
 
 export const DatePickerHelper = ({onOpen, onClose}) => {
+  const [hasMounted, setHasMounted] = useState(false);
   const [isModalOpen, setIsModalOpen] = useState(false);
+
+  useEffect(() => {
+    setHasMounted(true);
+  }, []);
 
   useEffect(() => {
     if (isModalOpen && onOpen) {
@@ -168,6 +173,10 @@ export const DatePickerHelper = ({onOpen, onClose}) => {
       onClose();
     }
   }, [isModalOpen]);
+
+  if (!hasMounted) {
+    return null;
+  }
 
   return (
     <>

--- a/front-end/components/business-process/common/support/date-picker-helper.js
+++ b/front-end/components/business-process/common/support/date-picker-helper.js
@@ -1,0 +1,261 @@
+import React, {useEffect, useState} from 'react';
+import {IconBolt, IconHelp, IconWand, IconX} from '@tabler/icons';
+import {Modal} from '@mui/material';
+import styled from 'styled-components';
+import {BPColors, BPDimens, BPStandards} from '../../../../utils/business-process/standards';
+
+// The styled div for the helper modal root.
+const HelperModalDiv = styled.div`
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 100%;
+  max-width: 700px;
+  max-height: 80vh;
+  background-color: ${BPColors.white};
+  
+  overflow: auto;
+  
+  &:focus {
+    outline: none;
+  }
+  
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: center;
+  
+  border: ${BPStandards.border};
+  border-radius: ${BPDimens.cornerRadius}px;
+  box-shadow: ${BPStandards.shadow};
+  
+  & .helper-modal-close-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    column-gap: 4px;
+    padding: 10px 11px 10px 14px;
+    margin: 0 10px;
+    border-radius: ${BPDimens.smallRadius}px;
+    font-size: 16px;
+    font-weight: 500;
+    color: ${BPColors.gray[400]};
+    transition: all 0.15s ease-in-out;
+    &:hover {
+      color: ${BPColors.black};
+      cursor: pointer;
+      background-color: ${BPColors.gray[100]};
+    }
+  }
+
+  & .helper-modal-content-container {
+    display: flex;
+    flex-direction: row;
+    align-items: flex-start;
+    justify-content: center;
+  }
+  
+  // Helper modal content styles.
+  & .helper-modal-content-children {
+    line-height: 1.7;
+
+    h1 {
+      margin: 0;
+      padding: 0;
+    }
+    
+    h2 {
+      font-size: 19px;
+      font-weight: 500;
+      color: ${BPColors.gray[900]};
+      margin: 0;
+      padding: 0;
+    }
+    
+    p {
+      font-size: 17px;
+      font-weight: 400;
+      color: ${BPColors.gray[900]};
+      margin: 0;
+      padding: 0;
+    }
+    
+    code {
+      font-size: 17px;
+      font-weight: 400;
+      color: ${BPColors.gray[900]};
+      margin: 0 2px;
+      padding: 4px 6px;
+      background-color: ${BPColors.gray[100]};
+      border-radius: ${BPDimens.smallRadius}px;
+    }
+  }
+`;
+
+// The subcomponent for the helper modal content.
+const HelperModalContentContainer = ({title, icon, color = BPColors.brand, children}) => {
+  const TitleIconComponent = icon;
+  return (
+    <div className="helper-modal-content-container">
+      <div
+        style={{
+          flexShrink: 0,
+          width: 42,
+          height: 42,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          marginLeft: 50,
+          borderRadius: BPDimens.smallRadius,
+          backgroundColor: color + '0f', // Fade out the color for background.
+        }}
+      >
+        <TitleIconComponent width={26} height={26} strokeWidth={1.9} color={color}/>
+      </div>
+      <div
+        className='helper-modal-content-children'
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          flexGrow: 1,
+          padding: '0px 20px',
+          rowGap: '12px',
+        }}
+      >
+        <h1
+          style={{
+            height: 42,
+            fontSize: 42,
+            fontWeight: '500',
+            lineHeight: 1.0,
+            display: 'flex',
+            flexDirection: 'row',
+            alignItems: 'flex-end',
+            justifyContent: 'flex-start',
+            color: color,
+          }}
+        >
+          {title}
+        </h1>
+        {children}
+      </div>
+    </div>
+  );
+};
+
+export const DatePickerHelper = ({onOpen, onClose}) => {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  useEffect(() => {
+    if (isModalOpen && onOpen) {
+      onOpen();
+    } else if (!isModalOpen && onClose) {
+      onClose();
+    }
+  }, [isModalOpen]);
+
+  return (
+    <>
+      <div
+        style={{
+          flex: 1,
+          display: 'flex',
+          justifyContent: 'center',
+          alignItems: 'center',
+          padding: '0 4px',
+          cursor: 'pointer',
+        }}
+        onClick={() => setIsModalOpen(true)}
+      >
+        <IconHelp
+          width={16}
+          height={16}
+          strokeWidth={2.2}
+        />
+      </div>
+      <Modal
+        open={isModalOpen}
+        onClose={() => setIsModalOpen(false)}
+        BackdropProps={{
+          style: {
+            backgroundColor: BPColors.white,
+            opacity: 0.65,
+          },
+        }}
+      >
+        <HelperModalDiv>
+          <div
+            style={{
+              width: '100%',
+              flexShrink: 0,
+              display: 'flex',
+              flexDirection: 'row',
+              alignItems: 'center',
+              justifyContent: 'space-between',
+              backgroundColor: BPColors.gray[50],
+              borderBottom: BPStandards.border,
+            }}
+          >
+            <div style={{
+              padding: '21px 25px',
+              color: BPColors.black,
+              fontSize: 20,
+              fontWeight: '500',
+            }}>
+              Shortcut Commands Help
+            </div>
+            <div
+              className="helper-modal-close-btn"
+              onClick={() => setIsModalOpen(false)}
+            >
+              <span>Close</span>
+              <IconX
+                width={22}
+                height={22}
+                strokeWidth={2.5}
+              />
+            </div>
+          </div>
+          <div
+            style={{
+              width: '100%',
+              height: '100%',
+              padding: '35px 20px 35px 20px',
+              overflowX: 'hidden',
+              overflowY: 'auto',
+              display: 'flex',
+              flexDirection: 'column',
+              alignItems: 'flex-start',
+              justifyContent: 'flex-start',
+              rowGap: 30,
+            }}
+          >
+            <HelperModalContentContainer title={'Magic Modifier'} icon={IconWand} color={'#db2777'}>
+              <p>
+                You can use the magic modifier to quickly select the date and time by thinking it in the most intuitive way.
+              </p>
+              <p>
+                One modifier is assembled by three parts: <b>Prefix</b>, <b>Amount</b> and <b>Unit</b>. Here are some examples: <code>+1d</code> (add a day), <code>-10h</code> (subtract 10 hours).
+              </p>
+              <p>
+                A prefix could be <code>+</code> or <code>-</code> to indicate the direction of the adjustment. If you want to pick a date (or time) that is in the past (need to subtract some times), you can use the prefix <code>-</code>. And if you want to pick a date (or time) that is in the future (need to add some times), you can use the prefix <code>+</code>.
+              </p>
+              <p>
+                To be continued...
+              </p>
+            </HelperModalContentContainer>
+            <HelperModalContentContainer title={'Supercharge Input'} icon={IconBolt} color={'#1d4ed8'}>
+              <p>
+                This is the most convenient way to &quot;paste&quot; a date and time.
+              </p>
+              <p>
+                To be continued.
+              </p>
+            </HelperModalContentContainer>
+          </div>
+        </HelperModalDiv>
+      </Modal>
+    </>
+  );
+};

--- a/front-end/components/business-process/common/support/date-picker-processor.js
+++ b/front-end/components/business-process/common/support/date-picker-processor.js
@@ -83,14 +83,15 @@ export function parseDate(userInput, baseDate) {
         throw new Error('Invalid minute.');
       }
 
-      const hourInt = parseInt(hour);
+      // If the user types `12am`, we need to set the hour to 0.
+      const hourInt = hour === '12' ? 0 : parseInt(hour);
       const minuteInt = parseInt(minute);
       const ampmInt = (matches[1] || 'am') === 'am' ? 0 : 12;
       updatedDate.setHours(hourInt + ampmInt);
       updatedDate.setMinutes(minuteInt);
-    } else if (currentModifier.toLowerCase().match(/\d+\/\d+\/\d+[,]?/g) /* If this is a date. */) {
+    } else if (currentModifier.toLowerCase().match(/^\d{1,2}\/\d\d{1,2}(?:|\/\d{2}|\/\d{4})[,]?$/g) /* If this is a date. */) {
       // Parse the date.
-      const matches = currentModifier.toLowerCase().match(/(\d+\/\d+\/\d+)[,]?/);
+      const matches = currentModifier.toLowerCase().match(/^(\d{1,2}\/\d\d{1,2}(?:|\/\d{2}|\/\d{4}))[,]?$/);
       if (matches.length < 1) {
         continue;
       }
@@ -98,14 +99,20 @@ export function parseDate(userInput, baseDate) {
       const dateArray = matches[1].split('/');
       const month = dateArray[0];
       const day = dateArray[1];
-      const year = dateArray[2];
+      const year = dateArray[2] || updatedDate.getFullYear();
       updatedDate.setMonth((parseInt(month) || 1) - 1); // -1 because the month starts from 0.
       updatedDate.setDate(parseInt(day) || 1);
       updatedDate.setFullYear(parseInt(year) || new Date().getFullYear());
+    } else if (['am', 'pm'].includes(currentModifier.toLowerCase()) /* If this is a standalone `am` or `pm`. */) {
+      // Parse the am/pm and add that to the updatedDate if needed.
+      const hour = updatedDate.getHours();
+      if (currentModifier.toLowerCase() === 'pm' && hour < 12) {
+        updatedDate.setHours(hour + 12);
+      }
     }
   }
 
-  // TODO.
+  // TODO: Remove the old version (below) after reviewing.
 
   // Below is the old version of the date parsing function.
   // The parsing logic is a bit tricky so I updated it to the newer function above.

--- a/front-end/components/business-process/common/support/date-picker-processor.js
+++ b/front-end/components/business-process/common/support/date-picker-processor.js
@@ -89,19 +89,26 @@ export function parseDate(userInput, baseDate) {
       updatedDate.setHours(hourInt + ampmInt);
       updatedDate.setMinutes(minuteInt);
     } else if (currentModifier.toLowerCase().match(/\d+\/\d+\/\d+[,]?/g) /* If this is a date. */) {
-      // TODO: Parse the date. WIP.
-      const date = currentModifier.match(/\d+\/\d+\/\d+/g)[0];
-      const dateArray = date.split('/');
+      // Parse the date.
+      const matches = currentModifier.toLowerCase().match(/(\d+\/\d+\/\d+)[,]?/);
+      if (matches.length < 1) {
+        continue;
+      }
+
+      const dateArray = matches[1].split('/');
       const month = dateArray[0];
       const day = dateArray[1];
       const year = dateArray[2];
-      updatedDate.setMonth(month - 1);
-      updatedDate.setDate(day);
-      updatedDate.setFullYear(year);
+      updatedDate.setMonth((parseInt(month) || 1) - 1); // -1 because the month starts from 0.
+      updatedDate.setDate(parseInt(day) || 1);
+      updatedDate.setFullYear(parseInt(year) || new Date().getFullYear());
     }
   }
 
   // TODO.
+
+  // Below is the old version of the date parsing function.
+  // The parsing logic is a bit tricky so I updated it to the newer function above.
 
   // const input = inputValue;
   // const inputValueArr = input.split(/[:\s]/i);

--- a/front-end/components/business-process/common/support/date-picker-processor.js
+++ b/front-end/components/business-process/common/support/date-picker-processor.js
@@ -1,0 +1,136 @@
+// This function is a mix of the `addAction` and `minusAction` functions because we can pass a negative value in.
+const changeDateByAmount = (base, amount, flag) => {
+  switch (flag) {
+    case 'h':
+      const newHour = parseInt(base.getHours()) + parseInt(amount);
+      base.setHours(newHour);
+      break;
+    case 'd':
+      const newDate = parseInt(base.getDate()) + parseInt(amount);
+      base.setDate(newDate);
+      break;
+    case 'm':
+      const newMinute = parseInt(base.getMinutes()) + parseInt(amount);
+      base.setMinutes(newMinute);
+      break;
+    case 'mo':
+      const newMonth = parseInt(base.getMonth()) + parseInt(amount);
+      base.setMonth(newMonth);
+      break;
+    case 'y':
+      const newYear = parseInt(base.getFullYear()) + parseInt(amount);
+      base.setFullYear(newYear);
+      break;
+  }
+};
+
+/**
+ * This function takes the user input string and returns the parsed date in the format of DateTime object.
+ *
+ * Expected behaviors:
+ * - Input: `-10d 9am` = 10 days ago at 9am.
+ * - Input: `-10d` = 10 days ago.
+ * - Input: `now -10h` = 10 hours ago from now.
+ * - Input: `12/20/2022 10AM` = `12/20/2022, 10:00 AM` (in Date object format).
+ *
+ * @param {string} userInput - The user input string.
+ * @param {Date} baseDate - The base date to be used for the parsing.
+ * @throws {Error} - Throws an error if the input is not valid.
+ * @return {Date} - DateTime object.
+ */
+export function parseDate(userInput, baseDate) {
+  // The date object to be returned.
+  let updatedDate = new Date(baseDate);
+
+  // Separate the user input string into an array of strings (in order to determine each modifier).
+  const modifiers = userInput.split(' ');
+
+  while (modifiers.length > 0) {
+    // Get the first element from the array.
+    const currentModifier = modifiers.shift();
+
+    if (currentModifier.length === 0) {
+      continue;
+    }
+
+    if (['-', '+'].includes(currentModifier.charAt(0)) /* If this is a date modifier. */) {
+      const prefix = currentModifier.charAt(0);
+      const amount = currentModifier.replace(/\D/g, '');
+      const flag = currentModifier.replace(/\W/g, '').replace(/\d/g, '').toLowerCase();
+      if (prefix === '+') {
+        changeDateByAmount(updatedDate, amount, flag);
+      } else {
+        changeDateByAmount(updatedDate, -amount, flag);
+      }
+    } else if (currentModifier.toLowerCase() === 'now' /* If this is a now modifier. */) {
+      // Override the updatedDate to the current date.
+      updatedDate = new Date();
+    } else if (currentModifier.toLowerCase().match(/^\d+:?\d*(am|pm)?$/g) /* If this is a time. */) {
+      // Parse the time.
+      const matches = currentModifier.toLowerCase().match(/^\d+:?\d*(am|pm)?$/);
+      if (matches.length < 1) {
+        continue;
+      }
+
+      const time = matches[0].replace(/(am|pm)/g, '');
+      const timeArray = time.split(':');
+      const hour = timeArray[0];
+      const minute = timeArray[1] || 0;
+
+      if ((hour > 12 && matches[1] === 'pm') || hour >= 24) {
+        throw new Error('Invalid hour.');
+      } else if (minute >= 60) {
+        throw new Error('Invalid minute.');
+      }
+
+      const hourInt = parseInt(hour);
+      const minuteInt = parseInt(minute);
+      const ampmInt = (matches[1] || 'am') === 'am' ? 0 : 12;
+      updatedDate.setHours(hourInt + ampmInt);
+      updatedDate.setMinutes(minuteInt);
+    } else if (currentModifier.toLowerCase().match(/\d+\/\d+\/\d+[,]?/g) /* If this is a date. */) {
+      // TODO: Parse the date. WIP.
+      const date = currentModifier.match(/\d+\/\d+\/\d+/g)[0];
+      const dateArray = date.split('/');
+      const month = dateArray[0];
+      const day = dateArray[1];
+      const year = dateArray[2];
+      updatedDate.setMonth(month - 1);
+      updatedDate.setDate(day);
+      updatedDate.setFullYear(year);
+    }
+  }
+
+  // TODO.
+
+  // const input = inputValue;
+  // const inputValueArr = input.split(/[:\s]/i);
+  //
+  // let parsedValue = inputValueArr[0];
+  // let hour = '00';
+  // let minutes = '00';
+  //
+  // if (inputValueArr.length > 1) {
+  //   hour = inputValueArr[1].replace(/\D/g, '');
+  //   parsedValue += ' ' + hour;
+  // }
+  // if (inputValueArr.length > 2) {
+  //   minutes = inputValueArr[2].replace(/\D/g, '');
+  //   if (/^\d+$/.test(minutes)) {
+  //     parsedValue += ':' + minutes;
+  //   }
+  // }
+  // if (input.toLowerCase().includes('am')) {
+  //   if (! /^\d+$/.test(minutes)) {
+  //     parsedValue += ':' + '00';
+  //   }
+  //   parsedValue += ' AM';
+  // } else if (input.toLowerCase().includes('pm')) {
+  //   if (! /^\d+$/.test(minutes)) {
+  //     parsedValue += ':' + '00';
+  //   }
+  //   parsedValue += ' PM';
+  // }
+
+  return updatedDate;
+}

--- a/front-end/components/business-process/common/text-input.js
+++ b/front-end/components/business-process/common/text-input.js
@@ -26,15 +26,9 @@ const BPTextInput = ({label, boxRef, value, onChange, onTextChange, placeholder,
         alignItems: 'flex-start',
         ...style,
       }}
-      onMouseEnter={() => {
-        setIsHovered(true);
-      }}
-      onMouseLeave={() => {
-        setIsHovered(false);
-      }}
     >
       {label ? (
-        <p style={labelStyle}>{label}</p>
+        <div style={labelStyle}>{label}</div>
       ) : <></>}
       <div
         style={{
@@ -55,6 +49,12 @@ const BPTextInput = ({label, boxRef, value, onChange, onTextChange, placeholder,
           if (onClick) {
             onClick(event);
           }
+        }}
+        onMouseEnter={() => {
+          setIsHovered(true);
+        }}
+        onMouseLeave={() => {
+          setIsHovered(false);
         }}
       >
         {beforeField || <></>}

--- a/front-end/components/business-process/tree/tree-filter.js
+++ b/front-end/components/business-process/tree/tree-filter.js
@@ -84,7 +84,7 @@ const BPTreeFilterComponent = ({onChange}) => {
           onChange={(newDate)=> {
             setEndDate(newDate);
           }}
-          baseDate={startDate}
+          baseDate={startDate || new Date()}
         />
 
         <BPDomainSelector

--- a/front-end/components/business-process/tree/tree-filter.js
+++ b/front-end/components/business-process/tree/tree-filter.js
@@ -74,8 +74,7 @@ const BPTreeFilterComponent = ({onChange}) => {
         <BPDatePicker
           label={'Start Date'}
           callBack={(e)=> {
-            startDate = e;
-            // console.log(startDate);
+            setStartDate(e);
           }}
           baseDate = {new Date()}
         />

--- a/front-end/components/business-process/tree/tree-filter.js
+++ b/front-end/components/business-process/tree/tree-filter.js
@@ -110,7 +110,7 @@ const BPTreeFilterComponent = ({onChange}) => {
           onChange={(newDate)=> {
             setEndDate(newDate);
           }}
-          baseDate={startDate || new Date()}
+          baseDate={startDate}
         />
 
         <BPDomainSelector

--- a/front-end/components/business-process/tree/tree-filter.js
+++ b/front-end/components/business-process/tree/tree-filter.js
@@ -73,10 +73,19 @@ const BPTreeFilterComponent = ({onChange}) => {
       >
         <BPDatePicker
           label={'Start Date'}
+          callBack={(e)=> {
+            startDate = e;
+            // console.log(startDate);
+          }}
+          baseDate = {new Date()}
         />
 
         <BPDatePicker
           label={'End Date'}
+          callBack={(e)=> {
+            endDate = e;
+          }}
+          baseDate = {startDate}
         />
 
         <BPDomainSelector

--- a/front-end/components/business-process/tree/tree-filter.js
+++ b/front-end/components/business-process/tree/tree-filter.js
@@ -73,18 +73,18 @@ const BPTreeFilterComponent = ({onChange}) => {
       >
         <BPDatePicker
           label={'Start Date'}
-          callBack={(e)=> {
-            setStartDate(e);
+          onChange={(newDate)=> {
+            setStartDate(newDate);
           }}
-          baseDate = {new Date()}
+          baseDate={new Date()}
         />
 
         <BPDatePicker
           label={'End Date'}
-          callBack={(e)=> {
-            endDate = e;
+          onChange={(newDate)=> {
+            setEndDate(newDate);
           }}
-          baseDate = {startDate}
+          baseDate={startDate}
         />
 
         <BPDomainSelector

--- a/front-end/package.json
+++ b/front-end/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@emotion/react": "^11.8.1",
     "@emotion/styled": "^11.8.1",
+    "@material-ui/core": "^4.12.3",
     "@mui/icons-material": "^5.4.4",
     "@mui/lab": "^5.0.0-alpha.73",
     "@mui/material": "^5.4.4",

--- a/front-end/package.json
+++ b/front-end/package.json
@@ -11,7 +11,6 @@
   "dependencies": {
     "@emotion/react": "^11.8.1",
     "@emotion/styled": "^11.8.1",
-    "@material-ui/core": "^4.12.3",
     "@mui/icons-material": "^5.4.4",
     "@mui/lab": "^5.0.0-alpha.73",
     "@mui/material": "^5.4.4",


### PR DESCRIPTION
This PR is related to issue #60 .

# Expected Functionality
- Support rough date format.
  - Sample format: `12/20/2022 9am`, `12/20/2022 9:00`, and `12/20/2022 9 AM` should all be able to parse automatically into `12/20/2022 9:00 AM` (the correct DateTime object).
- Support date modifier `h` (hour), `m` (minute), `d` (day), `mo` (month), `y` (year).
  - It includes three parts: modifier prefix (`-` or `+`), the modifying amount (a number), and the modifying unit (the shortcut for time units).
- Support multiple modifier at the same time.
  - Multiple modifier terms will be separated by spaces.
  - Sample format: `-1mo +1d 9am` equals to 1 month earlier, 1 day later (based on the modifier before), and at 9 AM.
- The start date field will parse the command based on current time.
- The end date field will parse the command based on the start date.
- Add help documentation for the shortcut commands.
- Support date format parsing and separated time format parsing (read from user input `9:00 AM`).
- Support the date format that only has month and day.
  - For example, `03/28` will be parsed into `3/28/2022` (do not modify the year).