### PR TITLE
[Indigo] [Cypress] Finish id-friendly changes for all essential components.

### DIFF
--- a/front-end/components/business-process/activity/activity-filter.js
+++ b/front-end/components/business-process/activity/activity-filter.js
@@ -1,4 +1,4 @@
-import React, {useState} from 'react';
+import React, {useEffect, useState} from 'react';
 import {BPDimens, BPStandards} from '../../../utils/business-process/standards';
 import {Button} from '@mui/material';
 import {BPDomainSelector} from '../common/domain-selector';
@@ -6,6 +6,16 @@ import {BPSeveritySelector} from '../common/severity-selector';
 import {BusinessDomainSample} from '../../../utils/business-process/sample-data';
 
 const BPActivityFilterComponent = ({onChange}) => {
+  const [selectedBusinessDomain, setSelectedBusinessDomain] = useState([]);
+  const [selectedSeverity, setSelectedSeverity] = useState([]);
+
+  useEffect(() => {
+    onChange({
+      businessDomain: selectedBusinessDomain,
+      severity: selectedSeverity,
+    });
+  }, [selectedBusinessDomain, selectedSeverity]);
+
   return (
     <div
       style={{
@@ -38,6 +48,7 @@ const BPActivityFilterComponent = ({onChange}) => {
           Activities Filter
         </p>
         <Button
+          id={'bp-activity-filter-apply-button'}
           size={'small'}
           sx={{
             color: 'white',
@@ -68,13 +79,17 @@ const BPActivityFilterComponent = ({onChange}) => {
         }}
       >
         <BPDomainSelector
+          id={'bp-activity-filter-business-domain-selector'}
           label={'Business Domain'}
           searchPlaceholder={'Search a business domain'}
           list={BusinessDomainSample}
+          onChange={(selected) => setSelectedBusinessDomain(selected)}
         />
 
         <BPSeveritySelector
+          id={'bp-activity-filter-severity-selector'}
           label={'Severity'}
+          onChange={(selected) => setSelectedSeverity(selected)}
         />
       </div>
     </div>

--- a/front-end/components/business-process/activity/activity-filter.js
+++ b/front-end/components/business-process/activity/activity-filter.js
@@ -10,10 +10,12 @@ const BPActivityFilterComponent = ({onChange}) => {
   const [selectedSeverity, setSelectedSeverity] = useState([]);
 
   useEffect(() => {
-    onChange({
-      businessDomain: selectedBusinessDomain,
-      severity: selectedSeverity,
-    });
+    if (onChange) {
+      onChange({
+        businessDomain: selectedBusinessDomain,
+        severity: selectedSeverity,
+      });
+    }
   }, [selectedBusinessDomain, selectedSeverity]);
 
   return (

--- a/front-end/components/business-process/common/button.js
+++ b/front-end/components/business-process/common/button.js
@@ -1,9 +1,11 @@
 import React from 'react';
 import {Button} from '@mui/material';
 
-const BPTextButton = ({children, ...props}) => {
+const BPTextButton = ({id = 'bp-text-button', children, ...props}) => {
   return (
     <Button
+      id={id}
+      {...props}
       onClick={props.onClick}
       variant="text"
       sx={{
@@ -20,9 +22,11 @@ const BPTextButton = ({children, ...props}) => {
   );
 };
 
-const BPButton = ({children, ...props}) => {
+const BPButton = ({id = 'bp-button', children, ...props}) => {
   return (
     <Button
+      id={id}
+      {...props}
       size={'small'}
       sx={{
         color: 'white',

--- a/front-end/components/business-process/common/checkbox.js
+++ b/front-end/components/business-process/common/checkbox.js
@@ -1,10 +1,16 @@
-import React, {useState} from 'react';
+import React, {useEffect, useState} from 'react';
 import {BPColors} from '../../../utils/business-process/standards';
 import {IconCheck} from '@tabler/icons';
 
-export const BPCheckbox = ({id = 'bp-checkbox', children, contentColor = BPColors.gray[400], idleColor = BPColors.gray[200], activeColor = BPColors.green[600], ...labelProps}) => {
+export const BPCheckbox = ({id = 'bp-checkbox', children, onChange, contentColor = BPColors.gray[400], idleColor = BPColors.gray[200], activeColor = BPColors.green[600], ...labelProps}) => {
   const [isChecked, setIsChecked] = useState(false);
   const [isHovered, setIsHovered] = useState(false);
+
+  useEffect(() => {
+    if (onChange) {
+      onChange(isChecked);
+    }
+  }, [isChecked]);
 
   return (
     <label

--- a/front-end/components/business-process/common/checkbox.js
+++ b/front-end/components/business-process/common/checkbox.js
@@ -2,12 +2,13 @@ import React, {useState} from 'react';
 import {BPColors} from '../../../utils/business-process/standards';
 import {IconCheck} from '@tabler/icons';
 
-export const BPCheckbox = ({checkboxProps, children, contentColor = BPColors.gray[400], idleColor = BPColors.gray[200], activeColor = BPColors.green[600]}) => {
+export const BPCheckbox = ({id = 'bp-checkbox', children, contentColor = BPColors.gray[400], idleColor = BPColors.gray[200], activeColor = BPColors.green[600], ...labelProps}) => {
   const [isChecked, setIsChecked] = useState(false);
   const [isHovered, setIsHovered] = useState(false);
 
   return (
     <label
+      id={id}
       style={{
         display: 'flex',
         flexDirection: 'row',
@@ -29,6 +30,7 @@ export const BPCheckbox = ({checkboxProps, children, contentColor = BPColors.gra
       onMouseLeave={() => {
         setIsHovered(false);
       }}
+      {...labelProps}
     >
       <div
         style={{

--- a/front-end/components/business-process/common/date-picker.js
+++ b/front-end/components/business-process/common/date-picker.js
@@ -14,7 +14,7 @@ import {DatePickerHelper} from './support/date-picker-helper';
 
 import {parseDate} from './support/date-picker-processor';
 
-export const BPDatePicker = ({label, onChange, baseDate}) => {
+export const BPDatePicker = ({id = 'bp-datepicker', label, onChange, baseDate}) => {
   // Date picker value.
   const [value, setValue] = useState(null);
 
@@ -30,11 +30,6 @@ export const BPDatePicker = ({label, onChange, baseDate}) => {
   const handlePopoverClose = () => {
     setIsOpen(false);
   };
-
-  // Process the input value into datepicker value.
-  useEffect(() => {
-    // setValue(parseDate(inputValue, baseDate));
-  }, [inputValue]);
 
   // Process the datepicker value into input value.
   useEffect(() => {
@@ -76,6 +71,7 @@ export const BPDatePicker = ({label, onChange, baseDate}) => {
           }}
         >
           <BPTextInput
+            id={id}
             style={{
               width: '100%',
             }}
@@ -111,7 +107,7 @@ export const BPDatePicker = ({label, onChange, baseDate}) => {
           />
 
           <Popper
-            id={isOpen ? 'bp-date-picker' : undefined}
+            id={isOpen ? `${id}-popper` : undefined}
             open={isOpen}
             anchorEl={boxRef.current}
             onClose={handlePopoverClose}

--- a/front-end/components/business-process/common/domain-selector-item.js
+++ b/front-end/components/business-process/common/domain-selector-item.js
@@ -2,11 +2,12 @@ import React, {useState} from 'react';
 import {BPColors, BPDimens} from '../../../utils/business-process/standards';
 import {IconCheck} from '@tabler/icons';
 
-export const BPDomainSelectorItem = ({item, selected, style, onClick}) => {
+export const BPDomainSelectorItem = ({id, item, selected, style, onClick}) => {
   const [isHovered, setIsHovered] = useState(false);
 
   return (
     <div
+      id={id}
       style={{
         padding: '10px 10px',
         cursor: 'pointer',

--- a/front-end/components/business-process/common/domain-selector.js
+++ b/front-end/components/business-process/common/domain-selector.js
@@ -6,8 +6,7 @@ import BPTextInput from './text-input';
 import {ClickAwayListener, Popper} from '@mui/material';
 import {BPDomainSelectorItem} from './domain-selector-item';
 
-export const BPDomainSelector = ({label, onChange, searchPlaceholder, list = []}) => {
-  const [displayValue, setDisplayValue] = useState('');
+export const BPDomainSelector = ({id = 'bp-domain-selector', label, onChange, searchPlaceholder, list = []}) => {
   const [selectedList, setSelectedList] = useState([]);
   const [searchInputValue, setSearchInputValue] = useState('');
 
@@ -36,13 +35,6 @@ export const BPDomainSelector = ({label, onChange, searchPlaceholder, list = []}
   }, [searchInputValue, list]);
 
   useEffect(() => {
-    if (selectedList.length > 0) {
-      setDisplayValue(
-          list.filter((item) => selectedList.includes(item)).join(', ')
-      );
-    } else {
-      setDisplayValue('All');
-    }
     if (onChange) {
       onChange(selectedList);
     }
@@ -93,6 +85,7 @@ export const BPDomainSelector = ({label, onChange, searchPlaceholder, list = []}
               <p style={labelStyle}>{label}</p>
             ) : <></>}
             <div
+              id={id}
               style={{
                 width: '100%',
                 display: 'flex',
@@ -166,7 +159,7 @@ export const BPDomainSelector = ({label, onChange, searchPlaceholder, list = []}
             </div>
           </div>
           <Popper
-            id={isOpen ? 'bp-date-picker' : undefined}
+            id={isOpen ? `${id}-popper` : undefined}
             open={isOpen}
             anchorEl={boxRef.current}
             onClose={handlePopoverClose}
@@ -210,6 +203,7 @@ export const BPDomainSelector = ({label, onChange, searchPlaceholder, list = []}
               }}
             >
               <BPTextInput
+                id={`${id}-popper-search`}
                 style={{
                   width: '100%',
                   flexShrink: 0,
@@ -219,6 +213,7 @@ export const BPDomainSelector = ({label, onChange, searchPlaceholder, list = []}
                 placeholder={searchPlaceholder || 'Search a domain'}
               />
               <div
+                id={`${id}-popper-list`}
                 style={{
                   width: '100%',
                   maxHeight: '40vh',
@@ -229,6 +224,7 @@ export const BPDomainSelector = ({label, onChange, searchPlaceholder, list = []}
                 }}
               >
                 <BPDomainSelectorItem
+                  id={`${id}-popper-item-all`}
                   item={'All'}
                   selected={selectedList.length === 0 || selectedList.includes('All')}
                   onClick={() => {

--- a/front-end/components/business-process/common/domain-selector.js
+++ b/front-end/components/business-process/common/domain-selector.js
@@ -108,6 +108,7 @@ export const BPDomainSelector = ({id = 'bp-domain-selector', label, onChange, se
               }}
             >
               <div
+                id={`${id}-selected-all`}
                 style={{
                   padding: '5px 5px',
                   fontSize: 16,
@@ -119,6 +120,7 @@ export const BPDomainSelector = ({id = 'bp-domain-selector', label, onChange, se
                 All
               </div>
               <div
+                id={`${id}-selected-items`}
                 style={{
                   display: 'flex',
                   flexDirection: 'row',
@@ -145,6 +147,7 @@ export const BPDomainSelector = ({id = 'bp-domain-selector', label, onChange, se
                   ))
                 }
                 <div
+                  id={`${id}-selected-more`}
                   style={{
                     paddingLeft: 4,
                     fontSize: 12,

--- a/front-end/components/business-process/common/severity-selector.js
+++ b/front-end/components/business-process/common/severity-selector.js
@@ -1,10 +1,11 @@
-import React, {useState} from 'react';
+import React, {useEffect, useState} from 'react';
 import {BPColors, BPDimens, BPStandards} from '../../../utils/business-process/standards';
 
 import {BPCheckbox} from './checkbox';
 
 export const BPSeveritySelector = ({id = 'bp-severity-selector', label, onChange, style, boxStyle}) => {
   const [isHovered, setIsHovered] = useState(false);
+  const [selectedSeverity, setSelectedSeverity] = useState([]);
 
   const labelStyle = {
     fontSize: 13,
@@ -16,6 +17,22 @@ export const BPSeveritySelector = ({id = 'bp-severity-selector', label, onChange
     color: BPColors.gray[400],
     transition: 'color 0.15s ease-in-out',
   };
+
+  const onCheckboxChange = (label) => {
+    return (isSelected) => {
+      if (isSelected) {
+        setSelectedSeverity([...selectedSeverity, label]);
+      } else {
+        setSelectedSeverity(selectedSeverity.filter((item) => item !== label));
+      }
+    };
+  };
+
+  useEffect(() => {
+    if (onChange) {
+      onChange(selectedSeverity);
+    }
+  }, [selectedSeverity]);
 
   return (
     <div
@@ -59,6 +76,7 @@ export const BPSeveritySelector = ({id = 'bp-severity-selector', label, onChange
           id={`${id}-success`}
           activeColor={BPColors.success}
           contentColor={BPColors.success}
+          onChange={onCheckboxChange('success')}
         >
           Success
         </BPCheckbox>
@@ -66,6 +84,7 @@ export const BPSeveritySelector = ({id = 'bp-severity-selector', label, onChange
           id={`${id}-info`}
           activeColor={BPColors.info}
           contentColor={BPColors.info}
+          onChange={onCheckboxChange('info')}
         >
           Info
         </BPCheckbox>
@@ -73,6 +92,7 @@ export const BPSeveritySelector = ({id = 'bp-severity-selector', label, onChange
           id={`${id}-warning`}
           activeColor={BPColors.warning}
           contentColor={BPColors.warning}
+          onChange={onCheckboxChange('warning')}
         >
           Warning
         </BPCheckbox>
@@ -80,6 +100,7 @@ export const BPSeveritySelector = ({id = 'bp-severity-selector', label, onChange
           id={`${id}-error`}
           activeColor={BPColors.error}
           contentColor={BPColors.error}
+          onChange={onCheckboxChange('error')}
         >
           Error
         </BPCheckbox>

--- a/front-end/components/business-process/common/severity-selector.js
+++ b/front-end/components/business-process/common/severity-selector.js
@@ -1,9 +1,9 @@
-import React, {useEffect, useRef, useState} from 'react';
+import React, {useState} from 'react';
 import {BPColors, BPDimens, BPStandards} from '../../../utils/business-process/standards';
 
 import {BPCheckbox} from './checkbox';
 
-export const BPSeveritySelector = ({label, onChange, style, boxStyle}) => {
+export const BPSeveritySelector = ({id = 'bp-severity-selector', label, onChange, style, boxStyle}) => {
   const [isHovered, setIsHovered] = useState(false);
 
   const labelStyle = {
@@ -37,6 +37,7 @@ export const BPSeveritySelector = ({label, onChange, style, boxStyle}) => {
         <p style={labelStyle}>{label}</p>
       ) : <></>}
       <div
+        id={id}
         style={{
           display: 'flex',
           flexDirection: 'row',
@@ -55,24 +56,28 @@ export const BPSeveritySelector = ({label, onChange, style, boxStyle}) => {
         }}
       >
         <BPCheckbox
+          id={`${id}-success`}
           activeColor={BPColors.success}
           contentColor={BPColors.success}
         >
           Success
         </BPCheckbox>
         <BPCheckbox
+          id={`${id}-info`}
           activeColor={BPColors.info}
           contentColor={BPColors.info}
         >
           Info
         </BPCheckbox>
         <BPCheckbox
+          id={`${id}-warning`}
           activeColor={BPColors.warning}
           contentColor={BPColors.warning}
         >
           Warning
         </BPCheckbox>
         <BPCheckbox
+          id={`${id}-error`}
           activeColor={BPColors.error}
           contentColor={BPColors.error}
         >

--- a/front-end/components/business-process/common/text-input.js
+++ b/front-end/components/business-process/common/text-input.js
@@ -3,7 +3,30 @@ import {BPColors, BPDimens, BPStandards} from '../../../utils/business-process/s
 
 import {InputBase} from '@mui/material';
 
-const BPTextInput = ({label, boxRef, value, onChange, onTextChange, placeholder, style, boxStyle, inputStyle, onFocus, onClick, onBlur, onEnterPress, onEscPress, disableInput, beforeField, afterField, ...props}) => {
+/**
+ * [BP] The text input component.
+ * @param {string} id - The id of the input. If you want to focus on the input field, use the id with `-field` trailing to input the content.
+ * @param {string|React.ReactNode} label - The label of the input.
+ * @param {function} boxRef - To get the input box (not input field) reference.
+ * @param {string} value - The value of the input.
+ * @param {function} onChange - The callback function (with event) when the input value is changed.
+ * @param {function} onTextChange - The callback function (with text value only) when the input value is changed.
+ * @param {string} placeholder - The placeholder of the input.
+ * @param {object} style - The style of the component root.
+ * @param {object} boxStyle - The style of the input box.
+ * @param {object} inputStyle - The style of the input field.
+ * @param {function} onFocus - The callback function when the input field is focused.
+ * @param {function} onClick - The callback function when the input field is clicked.
+ * @param {function} onBlur - The callback function when the input field is blurred.
+ * @param {function} onEnterPress - The callback function when the enter key is pressed.
+ * @param {function} onEscPress - The callback function when the esc key is pressed.
+ * @param {boolean} disableInput - The flag to disable the input field.
+ * @param {string|React.ReactNode} beforeField - The content before the input field.
+ * @param {string|React.ReactNode} afterField - The content after the input field.
+ * @param {object} props - The other properties of the component.
+ * @return {JSX.Element} - The component.
+ */
+const BPTextInput = ({id = 'bp-text-input', label, boxRef, value, onChange, onTextChange, placeholder, style, boxStyle, inputStyle, onFocus, onClick, onBlur, onEnterPress, onEscPress, disableInput, beforeField, afterField, ...props}) => {
   const [isFocused, setIsFocused] = useState(false);
   const [isHovered, setIsHovered] = useState(false);
 
@@ -31,6 +54,7 @@ const BPTextInput = ({label, boxRef, value, onChange, onTextChange, placeholder,
         <div style={labelStyle}>{label}</div>
       ) : <></>}
       <div
+        id={id}
         style={{
           display: 'flex',
           flexDirection: 'row',
@@ -59,6 +83,7 @@ const BPTextInput = ({label, boxRef, value, onChange, onTextChange, placeholder,
       >
         {beforeField || <></>}
         <InputBase
+          id={`${id}-field`}
           placeholder={placeholder}
           type={props.type || 'text'}
           style={{

--- a/front-end/components/business-process/tree/tree-filter.js
+++ b/front-end/components/business-process/tree/tree-filter.js
@@ -67,6 +67,7 @@ const BPTreeFilterComponent = ({onChange}) => {
           Business Process
         </p>
         <Button
+          id={'bp-tree-filter-apply-button'}
           size={'small'}
           sx={{
             color: 'white',
@@ -98,6 +99,7 @@ const BPTreeFilterComponent = ({onChange}) => {
         }}
       >
         <BPDatePicker
+          id={'bp-tree-filter-start-date-picker'}
           label={'Start Date'}
           onChange={(newDate)=> {
             setStartDate(newDate);
@@ -105,6 +107,7 @@ const BPTreeFilterComponent = ({onChange}) => {
         />
 
         <BPDatePicker
+          id={'bp-tree-filter-end-date-picker'}
           label={'End Date'}
           onChange={(newDate)=> {
             setEndDate(newDate);
@@ -113,6 +116,7 @@ const BPTreeFilterComponent = ({onChange}) => {
         />
 
         <BPDomainSelector
+          id={'bp-tree-filter-eai-domain-selector'}
           label={'EAI Domain'}
           searchPlaceholder={'Search an EAI domain'}
           list={eaiDomainList}
@@ -120,6 +124,7 @@ const BPTreeFilterComponent = ({onChange}) => {
         />
 
         <BPDomainSelector
+          id={'bp-tree-filter-publishing-business-domain-selector'}
           label={'Publishing Business Domain'}
           searchPlaceholder={'Search a publishing domain'}
           list={publishingBusinessDomainList}


### PR DESCRIPTION
# Description

This PR is related to the issue #102 . The goal of this PR is to make all components id-friendly, thus testers can easily select the component by directly looking for the id of every component.

# Changes

- Add `id` property to all BP essential components.
- Add id to all filter components.
- Fix some functionality issue found when adding id.