### PR TITLE
Alter data passing to log events

### DIFF
--- a/front-end/pages/dashboard/Count.js
+++ b/front-end/pages/dashboard/Count.js
@@ -4,53 +4,37 @@ import * as React from 'react';
 import Typography from '@mui/material/Typography';
 // import Title from './Title';
 import Card from '@mui/material/Card';
-import {CardContent} from '@mui/material';
+import { CardContent } from '@mui/material';
 import Grid from '@mui/material/Grid';
 import Button from '@mui/material/Button';
 import Link from 'next/link';
 
-// function preventDefault(event) {
-//     event.preventDefault();
-// }
 
 /**
  * @param {Object} props
 * @return {JSX.Element}
 */
 export default function Count(props) {
-  return (
-  // <>
-  // <Title>High Priority Logs</Title>
-  // <Typography component="p" variant="h4">
-  //     586
-  // </Typography>
-  // {/* TODO: make this a dropdown */}
-  // <Typography color="text.secondary" sx={{ flex: 1 }}>
-  // in the past 12 hours
-  // </Typography>
+  const seeMore = () => {
+    if (props.type === 'severity') {
+      props.onClick({ start: props.start, end: props.end, type: 'severity', severity: props.severity });
+    } else {
+      props.onClick({ start: props.start, end: props.end, type: 'priority', severity: props.priority })
+    }
+  }
 
-    // <div>
-    //     <Link color="primary" href="#" onClick={preventDefault}>
-    //         View logs
-    //     </Link>
-    // </div>
-    // </>
+  return (
     <Card>
       <CardContent>
-        <Typography sx={{fontSize: 14}} color="text.secondary" gutterBottom>
+        <Typography sx={{ fontSize: 14 }} color="text.secondary" gutterBottom>
           {props.countTitle}
         </Typography>
         <Typography component="p" variant="h4">
           {props.total}
         </Typography>
         <Grid container direction='row'>
-          {/* <Grid item xs={6}>
-                        <Typography>
-                            in the last {props.timeframe}
-                        </Typography>
-                    </Grid> */}
           <Grid item xs={6}>
-            <Button variant="text">
+            <Button variant="text" onClick={() => seeMore()}>
               <Link href='//LogEvent//' passHref>
                 <a>
                   See More

--- a/front-end/pages/dashboard/Counts.js
+++ b/front-end/pages/dashboard/Counts.js
@@ -1,7 +1,7 @@
 import Count from './Count';
 import Grid from '@mui/material/Grid';
 import ErrorOutlineRoundedIcon from '@mui/icons-material/ErrorOutlineRounded';
-import {red} from '@mui/material/colors';
+import { red } from '@mui/material/colors';
 
 /**
  * @param {Object} props
@@ -47,44 +47,50 @@ export default function Counts(props) {
   return (
     <Grid container direction='row' spacing={2}>
       <Grid item xs={3}>
-        {/* <Paper elevation={3}>
-                    <Box px={2} pt={4}>
-                      <Typography variant="h5" gutterBottom component="div">
-                        Count
-                      </Typography>
-                    </Box>
-                  </Paper> */}
-        <Count icon={<ErrorOutlineRoundedIcon sx={{color: red[500]}}/>} countTitle={'High Priority Logs'} total={sumHighPriority()} onClick={props.setFilters}/>
+        <Count
+          icon={<ErrorOutlineRoundedIcon
+            sx={{ color: red[500] }} />}
+          countTitle={'High Priority Logs'}
+          total={sumHighPriority()}
+          onClick={props.toggleLogEvents}
+          type='priority'
+          priority='High'
+          start={props.start}
+          end={props.end}
+        />
       </Grid>
       <Grid item xs={3}>
-        {/* <Paper elevation={3}>
-                    <Box px={2} pt={4}>
-                        <Typography variant="h5" gutterBottom component="div">
-                            Count
-                        </Typography>
-                    </Box>
-                </Paper> */}
-        <Count countTitle={'Medium Priority Logs'} total={sumMediumPriority()} onClick={props.setFilters}/>
+        <Count
+          countTitle={'Medium Priority Logs'}
+          total={sumMediumPriority()}
+          onClick={props.toggleLogEvents}
+          type='priority'
+          priority='Medium'
+          start={props.start}
+          end={props.end}
+        />
       </Grid>
       <Grid item xs={3}>
-        {/* <Paper elevation={3}>
-                    <Box px={2} pt={4}>
-                        <Typography variant="h5" gutterBottom component="div">
-                            Count
-                        </Typography>
-                    </Box>
-                </Paper> */}
-        <Count countTitle={'Errors'} total={sumErrors()} onClick={props.setFilters}/>
+        <Count
+          countTitle={'Error Logs'}
+          total={sumErrors()}
+          onClick={props.toggleLogEvents}
+          type='severity'
+          severity='Error'
+          start={props.start}
+          end={props.end}
+        />
       </Grid >
       <Grid item xs={3}>
-        {/* <Paper elevation={3}>
-                    <Box px={2} pt={4}>
-                        <Typography variant="h5" gutterBottom component="div">
-                            Count
-                        </Typography>
-                    </Box>
-                </Paper> */}
-        <Count countTitle={'Warnings'} total={sumWarnings()} onClick={props.setFilters}/>
+        <Count
+          countTitle={'Warning Logs'}
+          total={sumWarnings()}
+          onClick={props.toggleLogEvents} 
+          type='severity'
+          severity='Warning'
+          start={props.start}
+          end={props.end}
+          />
       </Grid>
     </Grid>
   );

--- a/front-end/pages/dashboard/Dashboard.js
+++ b/front-end/pages/dashboard/Dashboard.js
@@ -119,7 +119,11 @@ export default function Dashboard(props) {
               </Grid>
             </Grid>
             <Grid item xs={12}>
-              <Counts toggleLogEvents={props.toggleLogEvents} data={data.logEvents} />
+              <Counts
+                toggleLogEvents={props.toggleLogEvents}
+                data={data.logEvents}
+                start={moment().subtract(timeframe, 'minute')}
+                end={moment()} />
             </Grid>
             <Grid item xs={12}>
               <Grid container item direction='row' spacing={5}>
@@ -127,7 +131,12 @@ export default function Dashboard(props) {
                   <DonutCharts data={data.data} toggleBP={props.toggleBP} timeframe={timeframe} />
                 </Grid>
                 <Grid item xs={5}>
-                  <Timelines toggleLogEvents={props.toggleLogEvents} data={data.data} timeframe={timeframe} />
+                  <Timelines
+                    toggleLogEvents={props.toggleLogEvents}
+                    data={data.data}
+                    timeframe={timeframe}
+                    end={moment()}
+                  />
                 </Grid>
               </Grid>
             </Grid>

--- a/front-end/pages/dashboard/Dashboard.js
+++ b/front-end/pages/dashboard/Dashboard.js
@@ -31,12 +31,13 @@ export default function Dashboard(props) {
         console.log(data)
         return data.map((e) => {
           const cur = moment().subtract(tf, 'minute')
+          console.log("time: ", Math.floor(moment.duration(cur.diff(moment(e.creation_time))).as('minutes')))
           return {
             priority: getPriority(e.priority),
             type: getSeverity(e.severity),
-            time: moment.duration(cur.diff(moment(Math.floor(e.creation_time)))).as('minutes')
+            time: Math.floor(moment.duration(cur.diff(moment(e.creation_time))).as('minutes'))
           };
-        })
+        }).filter((e) => e.time >= 0).sort((a, b) => b.time - a.time)
       })
   }
 
@@ -62,6 +63,7 @@ export default function Dashboard(props) {
 
   const getData = (tf) => {
     getLogEvents(timeframe).then((data) => {
+      console.log("DATA: ", data)
       setData({
         logEvents: data,
         data: fakeData.filter((e) => e.time <= tf).sort((a, b) => b.time - a.time)
@@ -133,7 +135,7 @@ export default function Dashboard(props) {
                 <Grid item xs={5}>
                   <Timelines
                     toggleLogEvents={props.toggleLogEvents}
-                    data={data.data}
+                    data={data.logEvents}
                     timeframe={timeframe}
                     end={moment()}
                   />

--- a/front-end/pages/dashboard/Timeline.js
+++ b/front-end/pages/dashboard/Timeline.js
@@ -53,7 +53,7 @@ export default function Timeline(props) {
   };
 
   const getFilters = (start, end) => {
-    console.log('Get log events of type ' + props.type + ' from ' + start.format() + ' to ' + end.format());
+    // console.log('Get log events of type ' + props.type + ' from ' + start.format() + ' to ' + end.format());
 
     return {start: start, end: end, type: 'severity', severity: props.type};
   };

--- a/front-end/pages/dashboard/Timeline.js
+++ b/front-end/pages/dashboard/Timeline.js
@@ -104,7 +104,6 @@ export default function Timeline(props) {
           >
           </SplineSeries>
           <ArgumentAxis labelComponent={Label} />
-          {/* <ArgumentAxis /> */}
           <EventTracker onClick={onClickTimeline} />
           <HoverState
             hover={hover}

--- a/front-end/pages/dashboard/Timeline.js
+++ b/front-end/pages/dashboard/Timeline.js
@@ -47,17 +47,13 @@ export default function Timeline(props) {
     if (targets) {
       const index = targets[0].point;
       const point = props.data[index];
-      if (index == 0) {
-        props.toggleLogEvents(getFilters(point.time, point.time));
-        return;
-      }
-      const filters = getFilters(props.data[index - 1].time, point.time);
+      const filters = getFilters(point.time, point.time);
       props.toggleLogEvents(filters);
     }
   };
 
   const getFilters = (start, end) => {
-    console.log('Get log events of type ' + props.type + ' from ' + start + ' to ' + end);
+    console.log('Get log events of type ' + props.type + ' from ' + start.format() + ' to ' + end.format());
 
     return {start: start, end: end, type: 'severity', severity: props.type};
   };

--- a/front-end/pages/dashboard/Timeline.js
+++ b/front-end/pages/dashboard/Timeline.js
@@ -81,7 +81,6 @@ export default function Timeline(props) {
           </Typography>
         </Grid>
         <Grid item>
-          {/* Need to change linking to pass filters */}
           <Button
             variant="text"
             onClick={() => props.toggleLogEvents(getFilters(props.data[0].time, props.data[props.data.length - 1].time))}


### PR DESCRIPTION
Small change: after changing timeline point algorithm, forgot to adjust data passing function to properly pass the new timeframe per point when clicked. Just fixed it!

Since singular point now represents total # logs at that minute, we're passing in that point time (as moment object) as both start and end times. aka start and end times will be equal if clicking on a singular point on the graph. 